### PR TITLE
ダブルクオートを追加

### DIFF
--- a/MDN/TranslationHelper.user.js
+++ b/MDN/TranslationHelper.user.js
@@ -312,8 +312,8 @@
         applyLocalizedUrl() {
             // title: 記事URLを日本語版に修正
             // desc: /en-US/docs/ を /ja/docs/ などに置き換えます。
-            const newStr = this.work_str.replace(/"\/en-US\//g, '/ja/')
-            .replace(/"\/ja\/\//g, '/ja/')
+            const newStr = this.work_str.replace(/"\/en-US\//g, '"/ja/')
+            .replace(/"\/ja\/\//g, '"/ja/')
             // .replace(/"\/en-US\/Add-ons\//g, '/ja/Add-ons/')
             // .replace(/"\/en-US\/Apps\//g, '/ja/Apps/')
             .replace(/developer\.mozilla\.org\/en-US\//g, 'developer.mozilla.org/ja/');


### PR DESCRIPTION
現在、`TranslationHelper.user.js`を実行すると下記のようにhref属性を囲むダブルクオートの先頭のものが消えてしまいます。

- 実行前: `<a href="/en-US/docs/...`
- 実行後: `<a href=/ja/docs/...`

これを修正しました。
<strike>私にはユーザースクリプトの知識がなく、テストを行っていないので、確認をお願いいたします。</strike>
Tampermonkeyに登録してMDNの編集画面を開いたところ、正常にURLが変換されることを確認しました。
プルしていただけるようお願いします。