### PR TITLE
初期化で挿入される余分な空白を削除

### DIFF
--- a/MDN/TranslationHelper.user.js
+++ b/MDN/TranslationHelper.user.js
@@ -57,7 +57,7 @@
 
     class BodyProcessor {
         constructor() {
-            this.src_str = document.querySelector('.translate-source').textContent;
+            this.src_str = document.querySelector('.translate-source > textarea').textContent;
             this.editor = CKEDITOR.instances[Object.keys(CKEDITOR.instances)[0]];
             this.dest_str = this.editor.getData();
             this.work_str = this.dest_str;


### PR DESCRIPTION
(前回はmasterブランチにPRしてしまい、すみませんでした。)

現在、 `TranslationHelper.user.js`で「初期化」すると下記のように余分な空白が挿入されます。

##### 英語版のソース

```
<div>{{JSRef}}</div>

<p>The <code><strong>reduce()</strong></code> method applies ...

(中略)

<ul>
 <li>{{jsxref("Array.prototype.reduceRight()")}}</li>
</ul>
```

##### 「初期化」をクリック

```

                    <div>{{JSRef}}</div>

<p>The <code><strong>reduce()</strong></code> method applies ...

(中略)

<ul>
 <li>{{jsxref("Array.prototype.reduceRight()")}}</li>
</ul>
                
```

これを修正しました。
devブランチにマージしていただけるようお願いします。