### PR TITLE
自動翻訳を追加

### DIFF
--- a/MDN/TranslationHelper.user.js
+++ b/MDN/TranslationHelper.user.js
@@ -113,9 +113,9 @@
             // TODO: URLを見て適用するルールを限定する？
             const patterns = [
                 // common
-                ['h2', 'Specifications', '仕様'],
-                ['strong', 'Note:', '注:'],
-                ['strong', 'Note', '注'],
+                ['h2', 'Specifications?', '仕様'],
+                ['strong', 'Note(\:?)', '注$2'],
+                ['strong', 'Warning(\:?)', '警告$2'],
                 ['h2', 'Examples?', '例'],
                 ['h2', 'Browser compatibility', 'ブラウザー実装状況'],
                 ['h2', 'Notes', '注記'],
@@ -143,9 +143,9 @@
                 ['th', 'Comment', 'コメント'],
                 ['td', 'Initial (definition|specification)\.?', '初期定義'],
                 // common - constant table
-                ['th', 'Value', '値'],
+                ['(?:th|h3)', 'Values?', '値'],
                 ['th', 'Associated constant', '定数'],
-                ['th', 'Description', '説明'],
+                ['(?:th|h[2-3])', 'Description', '説明'],
                 // JavaScript API
                 ['h2', 'Methods', 'メソッド'],
                 ['h2', 'Properties', 'プロパティ'],
@@ -153,6 +153,9 @@
                 ['h3', 'Parameters', 'パラメーター'],
                 ['h3', 'Constants', '定数'],
                 ['h3', 'Exceptions', '例外'],
+                ['h3', 'Return value', '戻り値'],
+                ['h3', 'Result', '結果'],
+                ['h3', 'Formal syntax', '形式的構文'],
                 // DOM Elements
                 ['h3', 'Event handlers', 'イベントハンドラー'],
                 // Learning Area
@@ -180,7 +183,12 @@
                 ['dt', 'Cancelable', 'キャンセル可能か'],
                 ['dt', 'Target', 'ターゲット'],
                 ['dt', 'Default Action', '既定の動作'],
-                ['dd', 'None', 'なし']
+                ['dd', 'None', 'なし'],
+                // /docs/Web/CSS/
+                ['h2', 'Accessibility concerns', 'アクセシビリティへの配慮'],
+                ['', '\\/\\* +&lt;(\\w+)&gt; values? +\\*\\/', '/* &lt;$1&gt; 値 */'],
+                ['', '\\/\\* +Keyword values? +\\*\\/', '/* キーワード値 */'],
+                ['', '\\/\\* +Global values? +\\*\\/', '/* グローバル値 */']
             ];
             for (const pattern of patterns)
                 if (pattern[0] === ''){


### PR DESCRIPTION
今回はバグ報告ではなく、訳語追加の提案です。
下記すべてを追加してほしいというのではなく、あくまで提案です。
他のメンバーの方々と相談の上で、問題のないものだけを追加していただければと思います。

### 修正内容
```diff
- ['h2', 'Specifications', '仕様'],
+ ['h2', 'Specifications?', '仕様'],
```
Specifications (複数形) だけでなく、Specification (単数形) も対象に含めます。

- - -
```diff
- ['strong', 'Note:', '注:'],
- ['strong', 'Note', '注'],
+ ['strong', 'Note(\:?)', '注$2'],
```
記述を1つにまとめました。

- - -
```diff
+ ['strong', 'Warning(\:?)', '警告$2'],
```
`<strong>Warning:</strong>`を 「警告:」に変換します。

- - -
```diff
- ['th', 'Value', '値'],
+ ['(?:th|h3)', 'Values?', '値'],
```

`<th>`だけでなく`<h3>`も対象に含めます。
また、単数形だけでなく複数形も対象に含めます。

- - -
```diff
- ['th', 'Description', '説明'],
+ ['(?:th|h[2-3])', 'Description', '説明'],
```

`<th>`だけでなく`<h2>`, `<h3>`も対象に含めます。

- - -
```diff
+ ['h3', 'Return value', '戻り値'],
+ ['h3', 'Result', '結果'],
+ ['h3', 'Formal syntax', '形式的構文'],
+ ['h2', 'Accessibility concerns', 'アクセシビリティへの配慮'],
```

`<h3>Return value</h3>`を「戻り値」に、
`<h3>Result</h3>`を「結果」に、
`<h3>Formal syntax</h3>`を「形式的構文」に、
`<h2>Accessibility concerns</h2>`を「アクセシビリティへの配慮」に変換します。

- - -
```diff
+ ['', '\\/\\* +&lt;(\\w+)&gt; values? +\\*\\/', '/* &lt;$1&gt; 値 */'],
+ ['', '\\/\\* +Keyword values? +\\*\\/', '/* キーワード値 */'],
+ ['', '\\/\\* +Global values? +\\*\\/', '/* グローバル値 */']
```
CSSの「構文」セクションの中でよく見かける、
`/* &lt;length&gt; value */`や`/* &lt;percentage&gt; value */`を
`/* &lt;length&gt; 値 */`や`/* &lt;percentage&gt; 値 */`に、
`/* Keyword values */`を`/* キーワード値 */`に、
`/* Global values */`を`/* グローバル値 */`に変換します。
