### PR TITLE
ツール実行対象URLにwiki.developer.mozilla.orgを追加

### DIFF
--- a/MDN/TranslationHelper.user.js
+++ b/MDN/TranslationHelper.user.js
@@ -6,12 +6,12 @@
 // @version     0.4.8
 // @downloadURL https://raw.githubusercontent.com/mozilla-japan/translation/master/MDN/TranslationHelper.user.js
 // @supportURL  https://github.com/mozilla-japan/translation/issues
-// @match       https://developer.mozilla.org/en-US/docs/*
-// @match       https://developer.mozilla.org/en-US/Add-ons/*
-// @match       https://developer.mozilla.org/en-US/Apps/*
-// @match       https://developer.mozilla.org/ja/docs/*
-// @match       https://developer.mozilla.org/ja/Add-ons/*
-// @match       https://developer.mozilla.org/ja/Apps/*
+// @match       https://wiki.developer.mozilla.org/en-US/docs/*
+// @match       https://wiki.developer.mozilla.org/en-US/Add-ons/*
+// @match       https://wiki.developer.mozilla.org/en-US/Apps/*
+// @match       https://wiki.developer.mozilla.org/ja/docs/*
+// @match       https://wiki.developer.mozilla.org/ja/Add-ons/*
+// @match       https://wiki.developer.mozilla.org/ja/Apps/*
 // ==/UserScript==
 
 // 機能プランについてはGithubのプロジェクトに移動した


### PR DESCRIPTION
例えば以下のようなページを編集する場合、`wiki.`つきのドメインに転送されるため、`TranslationHelper.user.js`が発火しないという現象がありました。

閲覧用ページ: https://developer.mozilla.org/ja/docs/Web/API/StyleSheetList
編集用ページ: https://wiki.developer.mozilla.org/en-US/docs/Web/API/StyleSheetList$translate?tolocale=ja

UserScriptの`@match`に加筆し、どちらの場合でも実行対象のURLとなるよう修正しました。

| developer.mozilla.org | wiki.developer.mozilla.org |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/33276384/67139201-565e3780-f288-11e9-9cec-418c7c4bf031.png) | ![image](https://user-images.githubusercontent.com/33276384/67139190-39296900-f288-11e9-8da2-b8ab9aad6527.png) |
